### PR TITLE
There is no ida:AppKey in web.config, use ida:ClientSecret instead

### DIFF
--- a/O365-WebApp-MultiTenant/O365-WebApp-MultiTenant/Utils/SettingsHelper.cs
+++ b/O365-WebApp-MultiTenant/O365-WebApp-MultiTenant/Utils/SettingsHelper.cs
@@ -22,7 +22,7 @@ namespace O365_WebApp_MultiTenant.Utils
     public class SettingsHelper
     {
         private static string _clientId = ConfigurationManager.AppSettings["ida:ClientId"] ?? ConfigurationManager.AppSettings["ida:ClientID"];
-        private static string _appKey = ConfigurationManager.AppSettings["ida:AppKey"] ?? ConfigurationManager.AppSettings["ida:Password"];
+        private static string _appKey = ConfigurationManager.AppSettings["ida:ClientSecret"] ?? ConfigurationManager.AppSettings["ida:Password"];
 
         private static string _authorizationUri = "https://login.windows.net";
         private static string _graphResourceId = "https://graph.windows.net";


### PR DESCRIPTION
It looks like the *SettingsHelper* for retrieving the *AppKey* is incorrect. We should look for *ClientSecret* in the *web.config* file
see issue AuthKey => ClientSecret #7